### PR TITLE
unicorn-cap-removed

### DIFF
--- a/unicorn-worker-killer.gemspec
+++ b/unicorn-worker-killer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.licenses    = ["GPLv2+", "Ruby 1.8"]
   gem.require_paths = ['lib']
-  gem.add_dependency "unicorn",         [">= 4", "< 6"]
+  gem.add_dependency "unicorn",         ">= 4"
   gem.add_dependency "get_process_mem", "~> 0"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end


### PR DESCRIPTION
Dearest Reviewer,

In unicorn 6 they fixed an issue with recycling the env variable which can cause leakage. See https://github.blog/2021-03-18-how-we-found-and-fixed-a-rare-race-condition-in-our-session-handling/ and https://yhbt.net/unicorn-public/66A68DD8-83EF-4C7A-80E8-3F1F7AB31670@github.com/ for more details. 

changes
I just uncapped the gemfile for the moment.

becker